### PR TITLE
Handle Timeout rule and add tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,12 @@
             <artifactId>javaparser-symbol-solver-core</artifactId>
             <version>3.25.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -28,6 +34,14 @@
                 <configuration>
                     <source>17</source>
                     <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/org/example/converter/processor/RuleAnnotate/RuleTimeoutProcessor.java
+++ b/src/main/java/org/example/converter/processor/RuleAnnotate/RuleTimeoutProcessor.java
@@ -26,12 +26,13 @@ public class RuleTimeoutProcessor {
   public static void processTimeoutRule(CompilationUnit cu) {
     // 遍历所有字段声明
     cu.findAll(FieldDeclaration.class).forEach(field -> {
-      // 判断该字段是否有 @Rule 注解且类型为 Timeout
+      // 判断该字段是否有 @Rule/@ClassRule 注解且类型为 Timeout
       boolean hasRuleAnnotation = field.getAnnotations().stream()
-          .anyMatch(a -> a.getNameAsString().equals("Rule"));
+          .anyMatch(a -> a.getNameAsString().equals("Rule")
+              || a.getNameAsString().equals("ClassRule"));
 
       boolean isTimeoutType = field.getElementType().asString().equals("Timeout");
-      if (hasRuleAnnotation && isTimeoutType) {
+      if (isTimeoutType && (hasRuleAnnotation || field.getAnnotations().isEmpty())) {
         // 获取字段中定义的变量（通常只有一个）
         VariableDeclarator var = field.getVariable(0);
         Optional<Expression> initializerOpt = var.getInitializer();
@@ -47,29 +48,20 @@ public class RuleTimeoutProcessor {
               // 移除 JUnit4 的 Timeout rule 字段
               field.remove();
 
-              // 找到包含该字段的类，然后为该类中每个测试方法添加 @Timeout 注解
+              // 找到包含该字段的类，然后在类上添加 @Timeout 注解
               Optional<ClassOrInterfaceDeclaration> parentClassOpt =
                   field.findAncestor(ClassOrInterfaceDeclaration.class);
               if (parentClassOpt.isPresent()) {
                 ClassOrInterfaceDeclaration parentClass = parentClassOpt.get();
-                // 遍历该类中的所有方法
-                parentClass.findAll(MethodDeclaration.class).forEach(method -> {
-                  // 假定带有 @Test 注解的方法为测试方法
-                  boolean isTestMethod = method.getAnnotations().stream()
-                      .anyMatch(a -> a.getNameAsString().equals("Test"));
-                  if (isTestMethod) {
-                    // 如果方法上还没有 @Timeout 注解，则添加
-                    boolean hasTimeoutAnnotation = method.getAnnotations().stream()
-                        .anyMatch(a -> a.getNameAsString().equals("Timeout"));
-                    if (!hasTimeoutAnnotation) {
-                      AnnotationExpr timeoutAnnotation = new SingleMemberAnnotationExpr(
-                          new Name("Timeout"),
-                          new IntegerLiteralExpr(String.valueOf(timeoutSeconds))
-                      );
-                      method.addAnnotation(timeoutAnnotation);
-                    }
-                  }
-                });
+                boolean hasTimeoutAnnotation = parentClass.getAnnotations().stream()
+                    .anyMatch(a -> a.getNameAsString().equals("Timeout"));
+                if (!hasTimeoutAnnotation) {
+                  AnnotationExpr timeoutAnnotation = new SingleMemberAnnotationExpr(
+                      new Name("Timeout"),
+                      new IntegerLiteralExpr(String.valueOf(timeoutSeconds))
+                  );
+                  parentClass.addAnnotation(timeoutAnnotation);
+                }
               }
 
               // 修改导入：移除 JUnit4 的 Timeout 导入，添加 JUnit5 的 Timeout 导入（如果尚未添加）

--- a/src/test/java/org/example/converter/processor/RuleAnnotate/RuleTimeoutProcessorTest.java
+++ b/src/test/java/org/example/converter/processor/RuleAnnotate/RuleTimeoutProcessorTest.java
@@ -1,0 +1,36 @@
+package org.example.converter.processor.RuleAnnotate;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RuleTimeoutProcessorTest {
+
+    @Test
+    public void testTimeoutRuleConvertedToClassAnnotation() {
+        String source = String.join(System.lineSeparator(),
+            "import org.junit.Test;",
+            "import org.junit.rules.Timeout;",
+            "public class SampleTest {",
+            "  public Timeout globalTimeout = new Timeout(300000);",
+            "  @Test",
+            "  public void testA() {",
+            "  }",
+            "}");
+
+        CompilationUnit cu = StaticJavaParser.parse(source);
+        LexicalPreservingPrinter.setup(cu);
+
+        RuleTimeoutProcessor.processTimeoutRule(cu);
+
+        // 类上应添加 @Timeout 注解
+        assertTrue(cu.getClassByName("SampleTest").get()
+            .getAnnotationByName("Timeout").isPresent());
+
+        // 原始字段应该被移除
+        assertFalse(cu.toString().contains("globalTimeout"));
+    }
+}


### PR DESCRIPTION
## Summary
- support Timeout rule fields without annotations
- apply class-level `@Timeout` annotation when converting
- add unit test for RuleTimeoutProcessor
- add JUnit Jupiter test dependency

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685139b091a88332b8c62c1c37cd912a